### PR TITLE
 [CU-r779ej] Add-token-validation

### DIFF
--- a/server/controllers/authController.ts
+++ b/server/controllers/authController.ts
@@ -19,10 +19,10 @@ const cookieOptions: CookieOptions = {
   sameSite: 'strict',
 };
 
-const placeTokenInCookie = (token: msal.AuthenticationResult, req: Request, res: Response) => {
+const placeTokenInCookie = (token: string, req: Request, res: Response, tokenName: string) => {
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') { cookieOptions.secure = true; }
 
-  res.cookie('jwt', token.accessToken, cookieOptions);
+  res.cookie(tokenName, token, cookieOptions);
 };
 
 const config = {
@@ -30,6 +30,7 @@ const config = {
     clientId: `${process.env.CLIENT_ID}`,
     authority: `${process.env.AUTHORITY_URL}`,
     clientSecret: `${process.env.CLIENT_SECRET}`,
+    nonce: 123,
   },
   system: {
     loggerOptions: {
@@ -47,8 +48,7 @@ const loggingSession = new msal.ConfidentialClientApplication(config);
 export const login = catchAsync(
   async (req: Request, res: Response) => {
     const authCodeUrlParameters = {
-      scopes: ['user.read', 'user.readbasic.all', 'user.readwrite', 'user.read.all',
-        'user.readwrite.all', 'directory.read.all', 'directory.accessasuser.all'],
+      scopes: ['openid'],
       redirectUri: `${process.env.SSL === 'true' ? 'https' : 'http'}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}/login`,
     };
 
@@ -66,13 +66,18 @@ export const getToken = catchAsync(
   async (req: Request, res: Response) => {
     const tokenRequest = {
       code: req.body.code as string,
-      scopes: ['user.read'],
+      scopes: ['openid'],
+      nonce: 123,
       redirectUri: 'http://localhost:8080/login',
     };
-
     const token = await loggingSession.acquireTokenByCode(tokenRequest);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    placeTokenInCookie(token!, req, res);
-    res.status(200).end();
+    if (!token) {
+      return res.status(401).json({
+        message: 'Authentication failed',
+      });
+    }
+    placeTokenInCookie(token.accessToken, req, res, 'jwt');
+    placeTokenInCookie(token.idToken, req, res, 'validation_token');
+    return res.status(200).end();
   },
 );

--- a/server/middlewares/authenticationMiddleware.ts
+++ b/server/middlewares/authenticationMiddleware.ts
@@ -1,63 +1,24 @@
 import { Request, Response, NextFunction } from 'express';
 import * as jwt from 'jsonwebtoken';
-// import { verifyAzureToken } from 'azure-ad-jwt-lite';
-// import jwksClient from 'jwks-rsa';
+import jwksClient from 'jwks-rsa';
+import catchAsync from '../utils/catchAsync';
 
-export default async (req: Request, res: Response, next: NextFunction) => {
-  let token = '';
-
-  if (req.cookies.jwt) {
-    token = req.cookies.jwt;
+export default catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const client = jwksClient({
+    jwksUri: 'https://login.microsoftonline.com/5c17e85e-e180-4b9c-a8ff-5564a210ca4a/discovery/v2.0/keys',
+  });
+  const token = req.cookies.validation_token;
+  const decoded: any = jwt.decode(token, { complete: true });
+  const key = await client.getSigningKey(decoded?.header.kid);
+  const validToken: any = jwt.verify(token, key.getPublicKey());
+  if (validToken) {
+    req.decoded = {
+      userMSId: validToken.oid,
+    };
   } else {
     return res.status(401).json({
       message: 'Authentication failed',
     });
   }
-
-  // TU JEST NAJLEPSZY SPOSOB ALE NO AAAAAAAAA MS SPAPRAŁ ROBOTE
-  // const decoded = await verifyAzureToken(token, {
-  //   issuer: `https://sts.windows.net/${process.env.TENANT_ID}/`,
-  //   audience: `api://${process.env.CLIENT_ID}/user.read`,
-  // }) as any;
-  // OPCJA NR 2 lub 1
-  // const decoded = await verifyAzureToken(token) as any;
-
-  // req.decoded = {
-  //   userMSId: decoded.tid as string,
-  // };
-  // next();
-
-  // TUTAJ również poprawna bardziej basic opcja
-  /* const client = jwksClient({
-    jwksUri: `https://login.microsoftonline.com/${process.env.TENANT_ID}/discovery/keys`,
-    // jwksUri: `https://login.microsoftonline.com/${process.env.TENANT_ID}/discovery/v2.0/keys`,
-  });
-  function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
-    client.getSigningKey(header.kid, (err, key) => {
-      if (err) {
-        return res.status(401).json({
-          message: 'Authentication failed',
-        });
-      }
-
-      const signingKey = key.getPublicKey();
-      console.log('signingKey', signingKey);
-      callback(err, signingKey);
-    });
-  }
-*/
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const decoded = jwt.decode(token) as any;
-
-  if (!decoded) {
-    return res.status(401).json({
-      message: 'Authentication failed',
-    });
-  }
-
-  req.decoded = {
-    userMSId: decoded.oid,
-  };
-
   next();
-};
+});

--- a/server/middlewares/authenticationMiddleware.ts
+++ b/server/middlewares/authenticationMiddleware.ts
@@ -5,7 +5,7 @@ import catchAsync from '../utils/catchAsync';
 
 export default catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   const client = jwksClient({
-    jwksUri: 'https://login.microsoftonline.com/5c17e85e-e180-4b9c-a8ff-5564a210ca4a/discovery/v2.0/keys',
+    jwksUri: `https://login.microsoftonline.com/${process.env.TENANT_ID}/discovery/v2.0/keys`,
   });
   const token = req.cookies.validation_token;
   const decoded: any = jwt.decode(token, { complete: true });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,7 +10,7 @@ const indexRouter = express.Router();
 indexRouter.use(unless(authenticationMiddleware,
   '/v1/users/login',
   '/v1/users/logged',
-  '/v1/organization/logo', '/v1/organization/code'));
+  '/v1/organization/logo'));
 
 indexRouter.use('/v1/users/', userRouter);
 indexRouter.use('/v1/organization/', organizationRouter);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,7 +10,7 @@ const indexRouter = express.Router();
 indexRouter.use(unless(authenticationMiddleware,
   '/v1/users/login',
   '/v1/users/logged',
-  '/v1/organization/logo'));
+  '/v1/organization/logo', '/v1/organization/code'));
 
 indexRouter.use('/v1/users/', userRouter);
 indexRouter.use('/v1/organization/', organizationRouter);


### PR DESCRIPTION
Validation is perfectly working. The way I'm signing in and validating is called "Authorization code flow" BUT with openid scope which provides me with necessary token for validation called id_token. Microsoft generates two types of token. First type is meant to be used only with MS Graph and not for validating our own API, that's why it is just not validatable (that's why we couldn't validate it earlier, we had just this type of token). Second type is token just for validating our own API and for nothing else. This one is called id_token. To get this and not ruin whole signing in implemented methodology I've added "openid" scope to acquire id_token alongside access_token (meant only for MS Graph). It is **possible** that some functionalites may not be working but it is easy fixable. I just don't remember if I re-added all admin consents that were added before (I had to delete some of them while testing).
Ref
 -> https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 -> https://docs.microsoft.com/pl-pl/azure/active-directory/develop/v2-oauth2-auth-code-flow
![Zrzut ekranu z 2021-05-15 17-37-34](https://user-images.githubusercontent.com/50885549/118370127-95f51e80-b5a6-11eb-92ee-9289b46a84aa.png)
Especially last line is super important.

**Tl;dr;** Acquiring code is working in the same way that was working before. I've just added extra scope called 'openid' and that is generating extra token called id_token after `/token` endpoint is called (function `acquireTokenByCode` from MSAL). Then I am using this token for validation and the old token (We called it "jwt") for taking informations from Microsoft Graph.

**OTHER POSSIBLE SCENARIOS**
The way I'm doing it now is in my opinion the best way BUT I would like to describe other options, just for reference.
1. Auth code flow + openid scope --> while acquiring token we get extra token called id_token (solution that is implemented). Required small changes in MS Organization like allowing ID_tokens in Implicit Grant.
2. Auth code flow with  **ONLY** custom scope for our API (in our case it is 'api://btapp.com/besttournamentapp.read'). That is exactly this way: https://xsreality.medium.com/making-azure-ad-oidc-compliant-5734b70c43ff. But this solution has many disadvantages like: we are acquiring only token for validation our API. What with taking data from MS Organizations/Graph? That is the problem. To do this we have to acquire token **on behalf of the user**. That is bad solution because every time user wants to get some data from MS, backend has to acquire access token to MS Graph. Thats very unefficient.
3. Hybrid flow. This solution was interesting. It is described here: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow. It gives us ID_token before we acquire access_token however tehere are other disadvantages (responseMode must be form_post, which cuts request-response handshake on backend and that is the problem because we have to then manually redirect to frontend again. That is looking bad to me. Other problem is that msal-node's functionalities are beyond this. I would have to implement it manually.
