### PR TITLE
[CU-jd8d5d] Update details view

### DIFF
--- a/web-app/src/components/MultipleUsersAvatar.vue
+++ b/web-app/src/components/MultipleUsersAvatar.vue
@@ -55,14 +55,6 @@ export default class MultipleUsersAvatar extends Vue {
   @Prop({ type: Boolean, default: false }) readonly center!: boolean;
   @Prop({ type: Boolean, default: false }) readonly reverse!: boolean;
 
-  mounted() {
-    if (this.maxAvatars < 2) {
-      console.warn(
-        'Prop maxAvatars in MultipleUsersAvatar has a limitation: min 2'
-      );
-    }
-  }
-
   get restUsers() {
     if (this.users.length > this.maxAvatars)
       return this.users.slice(1, this.maxAvatars - 1);

--- a/web-app/src/components/MultipleUsersAvatar.vue
+++ b/web-app/src/components/MultipleUsersAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row" :class="reverse ? 'reverse' : ''">
+  <div class="row no-wrap" :class="reverse ? 'reverse' : ''">
     <user-avatar
       style="z-index: 100"
       :avatar-props="{ size: firstAvatarSize + 'px' }"

--- a/web-app/src/components/MultipleUsersAvatar.vue
+++ b/web-app/src/components/MultipleUsersAvatar.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="row" :class="reverse ? 'reverse' : ''">
+    <user-avatar
+      style="z-index: 100"
+      :avatar-props="{ size: firstAvatarSize + 'px' }"
+      :user="users[0]"
+    />
+    <user-avatar
+      :class="center ? 'self-center' : 'self-end'"
+      v-for="(user, index) in restUsers"
+      :style="{
+        margin: reverse ? '0 -8px 0 0' : '0 0 0 -8px',
+        'z-index': 99 - index,
+      }"
+      :key="user.id"
+      :avatar-props="{ size: restAvatarsSize + 'px' }"
+      :user="user"
+    />
+
+    <q-avatar
+      v-if="users.length > maxAvatars"
+      :class="center ? 'self-center' : 'self-end'"
+      :size="restAvatarsSize + 'px'"
+      :style="{
+        margin: reverse ? '0 -5px 0 0' : '0 0 0 -5px',
+        'z-index': 99 - users.length,
+      }"
+      color="grey-4"
+      text-color="black"
+      font-size="10px"
+    >
+      {{ '+' + (users.length - maxAvatars + 1) }}
+    </q-avatar>
+    <q-tooltip>
+      <div v-html="tooltipUserList"></div>
+    </q-tooltip>
+  </div>
+</template>
+
+<script lang="ts">
+import User from 'app/../shared/types/User';
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import UserAvatar from './UserAvatar.vue';
+
+@Component({
+  components: {
+    UserAvatar,
+  },
+})
+export default class MultipleUsersAvatar extends Vue {
+  @Prop({ type: Object, required: true }) readonly users!: User[];
+  @Prop({ type: Number, default: 36 }) readonly firstAvatarSize!: number;
+  @Prop({ type: Number, default: 28 }) readonly restAvatarsSize!: number;
+  @Prop({ type: Number, default: 2 }) readonly maxAvatars!: number;
+  @Prop({ type: Boolean, default: false }) readonly center!: boolean;
+  @Prop({ type: Boolean, default: false }) readonly reverse!: boolean;
+
+  mounted() {
+    if (this.maxAvatars < 2) {
+      console.warn(
+        'Prop maxAvatars in MultipleUsersAvatar has a limitation: min 2'
+      );
+    }
+  }
+
+  get restUsers() {
+    if (this.users.length > this.maxAvatars)
+      return this.users.slice(1, this.maxAvatars - 1);
+    else return this.users.slice(1);
+  }
+
+  get tooltipUserList() {
+    let stringList = '';
+
+    for (let i = 0; i < this.users.length; i++) {
+      stringList += `• ${this.users[i].firstName} ${this.users[i].lastName}<br/>`;
+    }
+    return stringList;
+  }
+}
+</script>

--- a/web-app/src/components/tournament/details/MatchComponent.vue
+++ b/web-app/src/components/tournament/details/MatchComponent.vue
@@ -27,7 +27,7 @@
 
       <div
         style="width: 100px"
-        class="q-ma-auto column self-center justify-center"
+        class="q-ma-auto q-mx-sm column self-center justify-center"
       >
         <!-- <div class="matchDate">{{ matchFormatedDate }}</div> -->
         <div style="text-align: center">

--- a/web-app/src/components/tournament/details/MatchComponent.vue
+++ b/web-app/src/components/tournament/details/MatchComponent.vue
@@ -5,10 +5,7 @@
     :style="small ? 'min-width: 300px' : 'min-width: 500px'"
     @click="scoreActionOnClick"
   >
-    <q-card-section
-      class="row no-wrap q-py-sm justify-between "
-      :class="[small ? 'q-px-sm' : 'q-px-md']"
-    >
+    <q-card-section class="row no-wrap q-py-sm q-px-md justify-between">
       <div style="flex: 1; min-width: 190px">
         <team-component
           :team="match.teamA"
@@ -41,7 +38,7 @@
         </div>
       </div>
 
-      <div v-if="!small" style="min-width: 190px">
+      <div v-if="!small" style="flex: 1; min-width: 190px">
         <team-component :team="match.teamB" flat inverted />
       </div>
     </q-card-section>

--- a/web-app/src/components/tournament/details/MatchComponent.vue
+++ b/web-app/src/components/tournament/details/MatchComponent.vue
@@ -42,6 +42,13 @@
         <team-component :team="match.teamB" flat inverted />
       </div>
     </q-card-section>
+    <q-tooltip
+      v-if="isAllowedToEditMatchScore"
+      :content-class="tooltipColor"
+      content-style="font-size: 13px; z-index: 5000"
+    >
+      {{ tooltipContent }}
+    </q-tooltip>
   </q-card>
 </template>
 
@@ -79,6 +86,17 @@ export default class MatchComponent extends Vue {
 
     if (this.isOwner && this.hasConflict) return 'matchConflictsFrame';
     return 'matchNewScoreFrame';
+  }
+
+  get tooltipContent() {
+    if (this.isOwner && this.hasConflict)
+      return this.$t('tournament.match.resolveConflict');
+    return this.$t('tournament.match.addScore');
+  }
+
+  get tooltipColor() {
+    if (this.isOwner && this.hasConflict) return 'bg-negative';
+    return 'bg-primary';
   }
 
   get formatedScore() {

--- a/web-app/src/components/tournament/details/ScoreTable.vue
+++ b/web-app/src/components/tournament/details/ScoreTable.vue
@@ -55,7 +55,6 @@ export default class ScoreTable extends Vue {
   private teamsScores: PointsPerTeam[] = [];
   private filter = '';
   private loading = true;
-  private expanded = '';
   private pagination = {
     rowsPerPage: 0,
     sortBy: 'points',

--- a/web-app/src/components/tournament/details/TeamComponent.vue
+++ b/web-app/src/components/tournament/details/TeamComponent.vue
@@ -6,9 +6,8 @@
     >
       <div
         v-if="inverted"
-        class="q-mr-xs text-right cut-name"
+        class="q-mr-xs text-right cut-team-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
-        style="font-size: 15px; flex: 1"
       >
         {{ team.name }}
       </div>
@@ -24,9 +23,8 @@
 
       <div
         v-if="!inverted"
-        class="q-ml-xs cut-name"
+        class="q-ml-xs cut-team-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
-        style="font-size: 15px;"
       >
         {{ team.name }}
       </div>
@@ -54,9 +52,10 @@ export default class TeamComponent extends Vue {
 </script>
 
 <style lang="scss" scoped>
-.cut-name {
+.cut-team-name {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  font-size: 15px;
 }
 </style>

--- a/web-app/src/components/tournament/details/TeamComponent.vue
+++ b/web-app/src/components/tournament/details/TeamComponent.vue
@@ -6,7 +6,7 @@
     >
       <div
         v-if="inverted"
-        class="q-mr-sm self-end text-right cut-name"
+        class="q-mr-xs text-right cut-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
         style="font-size: 15px; flex: 1"
       >
@@ -18,13 +18,13 @@
         :maxAvatars="2"
         :firstAvatarSize="iconSize"
         :restAvatarsSize="iconSize - 6"
-        :users="[...team.members, ...team.members]"
+        :users="team.members"
         :center="textCenter"
       />
 
       <div
         v-if="!inverted"
-        class="q-ml-sm cut-name"
+        class="q-ml-xs cut-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
         style="font-size: 15px;"
       >

--- a/web-app/src/components/tournament/details/TeamComponent.vue
+++ b/web-app/src/components/tournament/details/TeamComponent.vue
@@ -6,9 +6,9 @@
     >
       <div
         v-if="inverted"
-        class="q-mx-md self-end text-right"
+        class="q-mr-sm self-end text-right cut-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
-        style="font-size: 15px;"
+        style="font-size: 15px; flex: 1"
       >
         {{ team.name }}
       </div>
@@ -42,7 +42,7 @@
 
       <div
         v-if="!inverted"
-        class="q-mx-md"
+        class="q-ml-sm cut-name"
         :class="[textCenter ? 'self-center' : 'self-end']"
         style="font-size: 15px;"
       >
@@ -63,6 +63,13 @@ export default class TeamComponent extends Vue {
   @Prop({ type: Boolean, default: false }) readonly inverted!: boolean;
   @Prop({ type: Boolean, default: false }) readonly textCenter!: boolean;
   @Prop({ type: Number, default: 38 }) readonly iconSize!: number;
-  @Prop({ type: Boolean, default: false }) readonly dense!: boolean;
 }
 </script>
+
+<style lang="scss" scoped>
+.cut-name {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+</style>

--- a/web-app/src/components/tournament/details/TeamComponent.vue
+++ b/web-app/src/components/tournament/details/TeamComponent.vue
@@ -13,32 +13,14 @@
         {{ team.name }}
       </div>
 
-      <q-avatar
-        v-if="inverted"
-        class="self-end"
-        style="z-index: 10"
-        :size="iconSize + 'px'"
-      >
-        <!-- <img :src="team.members[0].avatarSrc" /> -->
-        <img src="https://cdn.quasar.dev/img/boy-avatar.png" />
-      </q-avatar>
-      <q-avatar
-        class="self-end"
-        :size="iconSize - 7 + 'px'"
-        :style="inverted ? 'margin-left: -8px' : 'margin-right: -8px'"
-      >
-        <!-- <img :src="team.members[1].avatarSrc" /> -->
-        <img src="https://cdn.quasar.dev/img/boy-avatar.png" />
-      </q-avatar>
-      <q-avatar
-        v-if="!inverted"
-        class="self-end"
-        style="z-index: 10"
-        :size="iconSize + 'px'"
-      >
-        <!-- <img :src="team.members[0].avatarSrc" /> -->
-        <img src="https://cdn.quasar.dev/img/boy-avatar.png" />
-      </q-avatar>
+      <multiple-users-avatar
+        :reverse="!inverted"
+        :maxAvatars="2"
+        :firstAvatarSize="iconSize"
+        :restAvatarsSize="iconSize - 6"
+        :users="[...team.members, ...team.members]"
+        :center="textCenter"
+      />
 
       <div
         v-if="!inverted"
@@ -55,8 +37,13 @@
 <script lang="ts">
 import { Team } from 'app/../shared/types/Tournament';
 import { Vue, Component, Prop } from 'vue-property-decorator';
+import MultipleUsersAvatar from '../../MultipleUsersAvatar.vue';
 
-@Component
+@Component({
+  components: {
+    MultipleUsersAvatar,
+  },
+})
 export default class TeamComponent extends Vue {
   @Prop({ type: Object, required: true }) readonly team!: Team;
   @Prop({ type: Boolean, default: false }) readonly flat!: boolean;

--- a/web-app/src/components/tournament/details/TournamentBracketMatch.vue
+++ b/web-app/src/components/tournament/details/TournamentBracketMatch.vue
@@ -6,7 +6,7 @@
     @click="scoreActionOnClick"
   >
     <q-card-section class="row no-wrap q-pa-xs" style="padding: 6px">
-      <div style="flex: 1">
+      <div style="width: 192px">
         <team-component
           v-if="match.teamA"
           style="padding-bottom: 6px"

--- a/web-app/src/components/tournament/details/TournamentBracketMatch.vue
+++ b/web-app/src/components/tournament/details/TournamentBracketMatch.vue
@@ -47,7 +47,7 @@
       </div>
     </q-card-section>
     <q-tooltip
-      v-model="isAllowedToEditMatchScore"
+      v-if="isAllowedToEditMatchScore"
       :content-class="tooltipColor"
       content-style="font-size: 13px; z-index: 5000"
     >

--- a/web-app/src/pages/tournament/TournamentDetails.vue
+++ b/web-app/src/pages/tournament/TournamentDetails.vue
@@ -1,38 +1,34 @@
 <template>
-  <q-page class="flex flex-center">
-    <q-spinner v-if="isLoading || !tournament" color="primary" size="3em" />
+  <q-page class="flex justify-center">
+    <q-spinner
+      v-if="isLoading || !tournament"
+      class="q-mt-xl"
+      color="primary"
+      size="3em"
+    />
     <q-card
       v-else
-      class="q-px-xs-none q-px-sm-md"
+      class="full-height q-px-xs-none q-px-sm-md"
       :class="{ fit: $q.screen.xs }"
     >
-      <q-tabs
-        v-if="tournament.type === 'round-robin'"
-        v-model="tab"
-        class="text-teal"
-      >
-        <q-tab :label="$t('tournament.details.tabs.matches')" name="matches" />
-        <q-tab
-          :label="$t('tournament.details.tabs.scoreboard')"
-          name="scoreboard"
-        />
-      </q-tabs>
       <q-card-section>
-        <div class="row">
+        <div class="row justify-center text-h5 q-mb-md q-mt-sm">
+          {{ tournament.name }}
+        </div>
+        <div class="row justify-center">
           <q-input
-            style="width:50%"
             borderless
             readonly
-            v-model="tournament.name"
-            autogrow
-            :label="$t('tournament.name')"
+            v-model="participantsAmount"
+            :label="$t('tournament.participantsAmount')"
           />
-          <q-field
+          <q-input
             borderless
-            :label="$t('tournament.organizer')"
-            stack-label
-            style="width:50%"
-          >
+            readonly
+            v-model="completedMatchesFormated"
+            :label="$t('tournament.match.played')"
+          />
+          <q-field borderless :label="$t('tournament.organizer')" stack-label>
             <template v-slot:control>
               <q-chip>
                 <q-avatar>
@@ -45,30 +41,30 @@
             </template>
           </q-field>
         </div>
-        <div class="row">
-          <q-input
-            borderless
-            style="width:50%"
-            readonly
-            v-model="participantsAmount"
-            :label="$t('tournament.participantsAmount')"
-          />
-          <q-input
-            style="width:50%"
-            borderless
-            readonly
-            v-model="completedMatchesFormated"
-            :label="$t('tournament.match.played')"
-          />
-        </div>
       </q-card-section>
+
+      <q-tabs
+        v-if="tournament.type === 'round-robin'"
+        v-model="tab"
+        class="text-teal"
+      >
+        <q-tab :label="$t('tournament.details.tabs.matches')" name="matches" />
+        <q-tab
+          :label="$t('tournament.details.tabs.scoreboard')"
+          name="scoreboard"
+        />
+      </q-tabs>
+
       <q-tab-panels
         v-if="tournament.type === 'round-robin'"
         v-model="tab"
         animated
       >
         <q-tab-panel name="matches">
-          <q-card-section class="q-px-xs-md">
+          <q-card-section
+            class="q-px-xs"
+            :style="$q.screen.xs ? '' : 'min-width: 535px'"
+          >
             <match-component
               :match="match"
               v-for="match in tournament.matches"
@@ -81,7 +77,7 @@
           </q-card-section>
         </q-tab-panel>
         <q-tab-panel name="scoreboard">
-          <q-card-section class="q-px-xs-md">
+          <q-card-section class="q-px-xs-md" style="min-width: 535px">
             <ScoreTable />
           </q-card-section>
         </q-tab-panel>

--- a/web-app/src/pages/tournament/TournamentDetails.vue
+++ b/web-app/src/pages/tournament/TournamentDetails.vue
@@ -62,8 +62,7 @@
       >
         <q-tab-panel name="matches">
           <q-card-section
-            class="q-px-xs"
-            :style="$q.screen.xs ? '' : 'min-width: 535px'"
+            :class="['q-px-xs', { 'tab-container': !$q.screen.xs }]"
           >
             <match-component
               :match="match"
@@ -77,16 +76,16 @@
           </q-card-section>
         </q-tab-panel>
         <q-tab-panel name="scoreboard">
-          <q-card-section class="q-px-xs-md" style="min-width: 535px">
+          <q-card-section
+            :class="['q-px-xs-md', { 'tab-container': !$q.screen.xs }]"
+          >
             <ScoreTable />
           </q-card-section>
         </q-tab-panel>
       </q-tab-panels>
 
       <q-card-section class="q-px-none" v-else>
-        <div
-          style="display: flex; overflow-x: auto; flex-wrap: nowrap; max-width: 1500px"
-        >
+        <div class="bracket-container">
           <tournament-bracket
             style="flex: 0 0 auto; padding: 15px"
             :matches="tournament.matches"
@@ -224,3 +223,15 @@ export default class TournamentDetails extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.tab-container {
+  min-width: 535px;
+}
+.bracket-container {
+  display: flex;
+  overflow-x: auto;
+  flex-wrap: nowrap;
+  max-width: 1500px;
+}
+</style>


### PR DESCRIPTION
The name of the tournament has been moved to the top-middle, rest of information has been moved to the second line.
All tooltips are displayed only on hover in both types of tournament.
Updated (no)wrapping of the team name.
Added `MultipleUsersAvatart` component to show avatars e.q 2 and '+5', additionally shows full list of users in tooltip on hover. This component could be used in tournament list view
![tooltip2](https://user-images.githubusercontent.com/24721386/119919147-14b86700-bf6a-11eb-88cd-ddbec12f7bb2.png)
![tooltip3](https://user-images.githubusercontent.com/24721386/119919148-15e99400-bf6a-11eb-9338-c6d15b1dbf76.png)
